### PR TITLE
chore: publish the component at /thoughts/ instead of /blog/

### DIFF
--- a/src/antora.yml
+++ b/src/antora.yml
@@ -1,4 +1,4 @@
-name: blog
+name: thoughts
 title: Blog
 version: ~
 start_page: index.adoc


### PR DESCRIPTION
Renames the Antora component from `blog` to `thoughts` so the unified [kieranpotts.com](https://kieranpotts.com) site publishes these posts under `/thoughts/` rather than `/blog/`.

- `src/antora.yml`: `name: blog` → `name: thoughts`. The display `title` stays **Blog**.
- No internal `xref:blog::` links exist in this repo (the nav uses relative xrefs), so nothing else here changes.

The matching changes live in the `website` repo (the index xref, navbar link, README, and `_redirects` — including a `/blog/* → /thoughts/:splat` catch-all so existing `/blog/<slug>` URLs keep resolving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)