### PR TITLE
chore: title the component "Thoughts" instead of "Blog"

### DIFF
--- a/src/antora.yml
+++ b/src/antora.yml
@@ -1,5 +1,5 @@
 name: thoughts
-title: Blog
+title: Thoughts
 version: ~
 start_page: index.adoc
 nav:

--- a/src/modules/ROOT/nav.adoc
+++ b/src/modules/ROOT/nav.adoc
@@ -1,4 +1,4 @@
-* xref:index.adoc[Blog]
+* xref:index.adoc[Thoughts]
 ** xref:mythical-man-month-50.adoc[The Mythical Man-Month at 50]
 ** xref:the-quality-without-a-name.adoc[The (software) quality without a name]
 ** xref:php-is-30.adoc[PHP is 30]


### PR DESCRIPTION
Follows the navbar rename on [kieranpotts.com](https://kieranpotts.com): the section is now labelled **Thoughts**, so this makes the component title and nav root label match for consistency throughout (breadcrumb, section heading).

- `src/antora.yml`: `title: Blog` → `title: Thoughts`
- `src/modules/ROOT/nav.adoc`: `xref:index.adoc[Blog]` → `[Thoughts]`

The component `name` (and therefore the `/thoughts/` URL) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)